### PR TITLE
Fix null filter issue and update datasets request to post

### DIFF
--- a/sql/plugin_mysql_pushdown/index.js
+++ b/sql/plugin_mysql_pushdown/index.js
@@ -21,6 +21,6 @@ const configureEndpoint = (method, endpoint, endpointFun) => {
 };
 
 configureEndpoint('post', '/authorize', controller.authorize);
-configureEndpoint('get', '/datasets', controller.datasets);
+configureEndpoint('post', '/datasets', controller.datasets);
 configureEndpoint('get', '/status', controller.status);
 configureEndpoint('post', '/query', controller.query);

--- a/sql/postgres/index.js
+++ b/sql/postgres/index.js
@@ -18,6 +18,6 @@ const configureEndpoint = ( method, endpoint, endpointFun ) => {
 }
 
 configureEndpoint( 'post', '/authorize', controller.authorize )
-configureEndpoint( 'get', '/datasets', controller.datasets )
+configureEndpoint( 'post', '/datasets', controller.datasets )
 configureEndpoint( 'get', '/status', controller.status )
 configureEndpoint( 'post', '/query', controller.query )

--- a/sql/postgres/src/plugin/query-generator.js
+++ b/sql/postgres/src/plugin/query-generator.js
@@ -92,7 +92,7 @@ class QueryGenerator {
         // There is a null value in the filter values
         isNullCondition = ` OR ${originalCaseColName} is null`
       }
-      return `${originalCaseColName} ${filter.expression} (${values.join( ',' )}) ${isNullCondition}`
+      return `(${originalCaseColName} ${filter.expression} (${values.join( ',' )}) ${isNullCondition})`
     }
     const values = this.parseExpressionValues( filter.value, columnInfo )
     if ( !util.isEmpty( values )) {

--- a/sql/sqlserver/index.js
+++ b/sql/sqlserver/index.js
@@ -18,6 +18,6 @@ const configureEndpoint = ( method, endpoint, endpointFun ) => {
 }
 
 configureEndpoint( 'post', '/authorize', controller.authorize )
-configureEndpoint( 'get', '/datasets', controller.datasets )
+configureEndpoint( 'post', '/datasets', controller.datasets )
 configureEndpoint( 'get', '/status', controller.status )
 configureEndpoint( 'post', '/query', controller.query )

--- a/sql/sqlserver/src/plugin/query-generator.js
+++ b/sql/sqlserver/src/plugin/query-generator.js
@@ -93,7 +93,7 @@ class QueryGenerator {
         // There is a null value in the filter values
         isNullCondition = ` OR ${originalCaseColName} is null`
       }
-      return `${originalCaseColName} ${filter.expression} (${values.join( ',' )}) ${isNullCondition}`
+      return `(${originalCaseColName} ${filter.expression} (${values.join( ',' )}) ${isNullCondition})`
     }
     const values = this.parseExpressionValues( filter.value, columnInfo )
     if ( !util.isEmpty( values )) {


### PR DESCRIPTION
1) Update to POST for /datasets requests
2) Fix null filter issue:
It seems that the queries generated are doing ‘where column in (123,...) or column is null and othercolumns ... ‘ instead of ‘where (column in (123,...) or column is null) and othercolumns ...‘